### PR TITLE
Add decision tree for choosing general/ vs safe_sv_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A community library of **industry-specific case analyses** for agentic workflows
 
 ## Table of Contents
 
+- [Quick start](#quick-start)
 - [What this repository is](#what-this-repository-is)
 - [Why this exists](#why-this-exists-the-submarine-analogy)
 - [How to use this repo](#how-to-use-this-repo)
@@ -22,6 +23,20 @@ A community library of **industry-specific case analyses** for agentic workflows
 - [Sub-verticals](#sub-verticals)
 - [Seeding strategy](#seeding-strategy-how-we-decide-what-to-write-next)
 - [Contributing](#contributing)
+
+---
+
+## Quick start
+
+**Reading a use case:**
+1. Browse [`verticals/`](verticals/) or use the [NAICS crosswalk table](#naics-2022--safe-use-case-id-crosswalk-human-readable-index)
+2. Open a use case README → review the workflow, threat model, and controls
+
+**Contributing a use case:**
+1. Pick a [workflow family](#workflow-families-shared-patterns-across-industries) and [vertical folder](#industry-navigation)
+2. Copy `templates/use-case-template.md` to `verticals/<vertical>/<subvertical>/your-use-case/README.md`
+3. Fill out the template, update `use-cases.naics2022.crosswalk.json`, and open a PR
+4. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for full guidelines
 
 ---
 


### PR DESCRIPTION
## Summary

- Add **Quick start** section as first item in Table of Contents
- Add a visual ASCII **decision tree** for choosing `general/` vs `safe_sv_*`
- Add **NAICS sector titles** to crosswalk table (e.g., "51 — Information")
- **Update ID policy**: Sub-verticals use folder name as identifier (avoids redundancy)

## Changes to ID Policy

**Before:**
> Sub-verticals do not receive IDs. They are organizational folders, not versioned artifacts.

**After:**
> Sub-verticals use the folder name as identifier (e.g., `safe_sv_software_saas`). The `safe_sv_` prefix signals SAFE-curated categories.

## Test plan

- [ ] Verify Quick start TOC link navigates correctly
- [ ] Verify the decision tree renders correctly on GitHub
- [ ] Verify NAICS titles display properly in the table
- [ ] Verify ID policy is consistent between README and CONTRIBUTING

🤖 Generated with [Claude Code](https://claude.ai/code)