### PR TITLE
feat: add SAFE-UC-0033 draft for skill-driven PR regression testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,13 +83,14 @@ Quick contributor workflow:
 | [SAFE-UC-0022](use-cases/SAFE-UC-0022/) | Security operations investigation assistant | [Professional, Scientific, and Technical Services (54)][naics-54] | Seed |
 | [SAFE-UC-0023](use-cases/SAFE-UC-0023/) | Cloud ops troubleshooting assistant | [Information (51)][naics-51] | Seed |
 | [SAFE-UC-0024](use-cases/SAFE-UC-0024/) | Terminal-based outage assistant for SRE | [Information (51)][naics-51] | Seed |
-| [SAFE-UC-0025](use-cases/SAFE-UC-0025/) | Skill-driven web app regression testing assistant for pull requests | [Information (51)][naics-51]<br>[Software Publishers (513210)][naics-513210] | Draft |
+| [SAFE-UC-0025](use-cases/SAFE-UC-0025/) | Enterprise agent-building platform | [Information (51)][naics-51] | Seed |
 | [SAFE-UC-0026](use-cases/SAFE-UC-0026/) | At-scale content policy enforcement pipeline | [Information (51)][naics-51] | Seed |
 | [SAFE-UC-0027](use-cases/SAFE-UC-0027/) | Anti-scam messaging safety assistant | [Information (51)][naics-51] | Seed |
 | [SAFE-UC-0028](use-cases/SAFE-UC-0028/) | Fake-account & inauthentic behavior detection assistant | [Information (51)][naics-51] | Seed |
 | [SAFE-UC-0029](use-cases/SAFE-UC-0029/) | Automated ad campaign optimization assistant | [Professional, Scientific, and Technical Services (54)][naics-54] | Seed |
 | [SAFE-UC-0030](use-cases/SAFE-UC-0030/) | Teen safety & age-assurance enforcement assistant | [Information (51)][naics-51] | Seed |
 | [SAFE-UC-0032](use-cases/SAFE-UC-0032/) | Agentic orchestration for marketplace embedded lending | [Finance and Insurance (52)][naics-52]<br>[Other Activities Related to Credit Intermediation (522390)][naics-522390]<br>[Electronic Shopping and Mail-Order Houses (454110)][naics-454110] | Draft |
+| [SAFE-UC-0033](use-cases/SAFE-UC-0033/) | Skill-driven web app regression testing assistant for pull requests | [Information (51)][naics-51]<br>[Software Publishers (513210)][naics-513210] | Draft |
 
 ---
 

--- a/use-cases.naics2022.crosswalk.json
+++ b/use-cases.naics2022.crosswalk.json
@@ -344,56 +344,16 @@
   },
   {
     "id": "SAFE-UC-0025",
-    "title": "Skill-driven web app regression testing assistant for pull requests",
-    "status": "draft",
+    "title": "Enterprise agent-building platform",
+    "status": "seed",
     "repo_path": "use-cases/SAFE-UC-0025/README.md",
     "naics_2022": [
       {
         "code": "51",
         "name": "Information"
-      },
-      {
-        "code": "513210",
-        "name": "Software Publishers"
       }
     ],
-    "summary": "Use coding-agent skills to run PR regression checks, summarize failures, and propose guarded fixes while enforcing strict permission boundaries.",
-    "workflow_family": "Software engineering & developer tooling",
-    "operating_modes": [
-      "manual",
-      "hitl",
-      "autonomous"
-    ],
-    "tags": [
-      "coding-agent",
-      "skills",
-      "regression-testing",
-      "pull-requests",
-      "playwright",
-      "ci-cd"
-    ],
-    "evidence": [
-      {
-        "label": "Anthropic skills repository (community and official skills)",
-        "url": "https://github.com/anthropics/skills"
-      },
-      {
-        "label": "Claude Code slash commands and skill invocation docs",
-        "url": "https://code.claude.com/docs/en/slash-commands"
-      },
-      {
-        "label": "Anthropic engineering post on agent skills in production",
-        "url": "https://claude.com/blog/equipping-agents-for-the-real-world-with-agent-skills"
-      },
-      {
-        "label": "GitHub Actions documentation for CI workflows",
-        "url": "https://docs.github.com/en/actions"
-      },
-      {
-        "label": "Playwright documentation",
-        "url": "https://playwright.dev/docs/intro"
-      }
-    ]
+    "summary": "Enterprise platform to build and deploy agents (tools, policies, monitoring) with governance and isolation controls."
   },
   {
     "id": "SAFE-UC-0026",
@@ -512,6 +472,59 @@
       {
         "label": "CFPB — Fair Lending and ECOA Compliance",
         "url": "https://www.consumerfinance.gov/compliance/supervisory-highlights/fair-lending/"
+      }
+    ]
+  },
+  {
+    "id": "SAFE-UC-0033",
+    "title": "Skill-driven web app regression testing assistant for pull requests",
+    "status": "draft",
+    "repo_path": "use-cases/SAFE-UC-0033/README.md",
+    "naics_2022": [
+      {
+        "code": "51",
+        "name": "Information"
+      },
+      {
+        "code": "513210",
+        "name": "Software Publishers"
+      }
+    ],
+    "summary": "Use coding-agent skills to run PR regression checks, summarize failures, and propose guarded fixes while enforcing strict permission boundaries.",
+    "workflow_family": "Software engineering & developer tooling",
+    "operating_modes": [
+      "manual",
+      "hitl",
+      "autonomous"
+    ],
+    "tags": [
+      "coding-agent",
+      "skills",
+      "regression-testing",
+      "pull-requests",
+      "playwright",
+      "ci-cd"
+    ],
+    "evidence": [
+      {
+        "label": "Anthropic skills repository (community and official skills)",
+        "url": "https://github.com/anthropics/skills"
+      },
+      {
+        "label": "Claude Code slash commands and skill invocation docs",
+        "url": "https://code.claude.com/docs/en/slash-commands"
+      },
+      {
+        "label": "Anthropic engineering post on agent skills in production",
+        "url": "https://claude.com/blog/equipping-agents-for-the-real-world-with-agent-skills"
+      },
+      {
+        "label": "GitHub Actions documentation for CI workflows",
+        "url": "https://docs.github.com/en/actions"
+      },
+      {
+        "label": "Playwright documentation",
+        "url": "https://playwright.dev/docs/intro"
       }
     ]
   }

--- a/use-cases/SAFE-UC-0025/README.md
+++ b/use-cases/SAFE-UC-0025/README.md
@@ -1,264 +1,32 @@
-# Skill-driven web app regression testing assistant for pull requests
+# Enterprise agent-building platform
 
-> **SAFE-AUCA industry reference guide (draft)**
->
-> This use case describes a workflow where engineering teams use a coding agent with reusable skills to run pull request (PR) regression checks for web applications.
->
-> It focuses on:
-> - how the workflow works in practice (tools, data, trust boundaries, autonomy)
-> - what can go wrong (defender-friendly kill chain)
-> - how it maps to **SAFE-MCP techniques**
-> - what controls + tests make it safer
->
-> **Defender-friendly only:** do **not** include operational exploit steps, payloads, or step-by-step attack instructions.  
-> **No sensitive info:** do not include internal hostnames/endpoints, secrets, customer data, non-public incidents, or proprietary details.
-
----
+> Seed page for **SAFE-AUCA**. Expand this into a full analysis using [`templates/use-case-template.md`](../../templates/use-case-template.md).
 
 ## Metadata
 
 | Field | Value |
 |---|---|
 | **SAFE Use Case ID** | `SAFE-UC-0025` |
-| **Status** | `draft` |
-| **NAICS 2022** | `51` (Information), `513210` (Software Publishers) |
-| **Workflow family** | `Software engineering & developer tooling` |
-| **Last updated** | `2026-02-18` |
+| **Status** | `seed` |
+| **NAICS 2022** | `Information (51)` |
+| **Last updated** | `2026-02-17` |
 
-### Evidence (public links)
-- https://github.com/anthropics/skills
-- https://code.claude.com/docs/en/slash-commands
-- https://claude.com/blog/equipping-agents-for-the-real-world-with-agent-skills
-- https://docs.github.com/en/actions
-- https://playwright.dev/docs/intro
+## Workflow Description (Seed)
 
----
+Enterprise platform to build and deploy agents (tools, policies, monitoring) with governance and isolation controls.
 
-## 1. Executive summary (what + why)
+## In Scope / Out Of Scope
 
-**What this workflow does**  
-Teams define reusable coding-agent skills (instructions, scripts, guardrails) for UI regression checks on PRs. The assistant runs deterministic test workflows (for example Playwright suites), summarizes failures, and proposes scoped fixes.
+- **In scope:** TBD
+- **Out of scope:** TBD
 
-**Why it matters (business value)**  
-This reduces release risk and developer wait time by standardizing repetitive QA tasks, improving triage speed, and making test execution more consistent across contributors.
+## SAFE-MCP Mapping (Seed Skeleton)
 
-**Why it is risky / what can go wrong**  
-The same automation can also increase blast radius. Untrusted PR content can influence tool behavior, secrets can leak in logs or artifacts, and autonomous write operations can introduce regressions or unsafe infrastructure changes.
-
----
-
-## 2. Industry context & constraints (reference-guide lens)
-
-- **Industry-specific constraints:** rapid release cadence, CI cost controls, branch protection requirements, secure SDLC expectations.
-- **Typical systems in this workflow:** git hosting, CI runners, package registries, artifact stores, test infrastructure, incident chat/tools.
-- **Must-not-fail outcomes:** no secret leakage in test logs, no unauthorized code or workflow changes, no silent test bypass, no unsafe auto-merge.
-- **Operational constraints:** minutes-level feedback loops, flaky test handling, reproducibility across developer/CI environments, strict least-privilege access.
-
----
-
-## 3. Workflow description & scope
-
-### 3.1 Workflow steps (happy path)
-1. Developer opens or updates a PR.
-2. Assistant loads the relevant skill (test strategy, allowed tools, approval gates).
-3. Assistant runs read-only analysis and targeted regression tests.
-4. Assistant summarizes failures with evidence (trace IDs, screenshots, failing assertions).
-5. Human reviewer approves any write actions (patches, workflow edits, retries with changed settings).
-6. CI reruns and PR proceeds through standard branch protections.
-
-### 3.2 In scope / out of scope
-- **In scope:** PR diff analysis, regression-test execution, failure summarization, proposed code/test fixes, CI-safe reruns.
-- **Out of scope:** production deployment approval, credential rotation, infra privilege escalation, bypassing branch protections.
-
-### 3.3 Assumptions
-- Branch protection and mandatory checks are already enforced.
-- Skill execution is versioned and reviewable.
-- High-risk writes require explicit human approval.
-
-### 3.4 Success criteria
-- Reduced regression escapes and mean-time-to-triage.
-- No unauthorized writes outside approved repo paths.
-- No sensitive data in assistant outputs or artifacts.
-- Reproducible test results between local and CI environments.
-
----
-
-## 4. System & agent architecture
-
-### 4.1 Actors and systems
-- **Human roles:** application engineers, QA engineers, release managers, security reviewers.
-- **Agent/orchestrator:** coding assistant runtime with skill loader and execution policy.
-- **Tools:** git CLI, test runners (for example Playwright), package manager, CI APIs, issue/PR APIs.
-- **Data stores:** source repo, CI logs/artifacts, test snapshots, skill definitions.
-- **Downstream systems affected:** PR status checks, codebase, test baselines, release gates.
-
-### 4.2 Trusted vs untrusted inputs
-
-| Input/source | Trusted? | Why | Typical failure/abuse pattern | Mitigation theme |
+| Kill-chain stage | Failure/attack pattern | SAFE-MCP technique(s) | Recommended controls | Tests |
 |---|---|---|---|---|
-| PR title/body/comments | Untrusted | user supplied | prompt injection/social engineering | treat as data, never instructions |
-| Changed files in PR | Untrusted | potentially malicious | test bypass, hidden payloads | policy checks + diff-aware allowlists |
-| Skill definitions | Semi-trusted | internal but editable | unsafe guidance drift | signed/versioned skills + review |
-| CI environment variables | Sensitive | high impact if leaked | credential exposure | redaction + scoped tokens |
-| Test artifacts/logs | Mixed | may include secrets/PII | data leakage | scrub + retention controls |
-| Tool outputs | Mixed | depends on tool | contaminated context | schema validation + provenance |
+| TBD | TBD | TBD | TBD | TBD |
 
-### 4.3 Trust boundaries (required)
-- **Developer/PR content -> agent boundary:** untrusted text and code cross into model context.
-- **Agent -> tool boundary:** model intent is translated into executable commands.
-- **Tool -> CI/API boundary:** actions may mutate external systems (checks, comments, artifacts).
-- **Dev/test -> protected branch boundary:** only policy-compliant changes may merge.
+## Next Steps
 
-### 4.4 Tool inventory (required)
-
-| Tool / MCP server | Read / write? | Permissions | Typical inputs | Typical outputs | Failure modes |
-|---|---|---|---|---|---|
-| `repo.diff.read` | read | PR-scoped | branch/ref | file diffs | missed risky file changes |
-| `test.run.playwright` | read/exec | sandboxed runner | test filters/config | pass/fail + traces | flaky runs, hidden side effects |
-| `ci.checks.read` | read | checks API scope | PR id/workflow id | status, logs | stale/incomplete status |
-| `pr.comment.create` | write | commenter scope | markdown summary | posted comment | leakage of sensitive details |
-| `repo.patch.apply` | write | branch-scoped + approval | diff/patch | updated files | incorrect or over-broad edits |
-
-### 4.5 Governance & authorization matrix
-
-| Action category | Example actions | Allowed mode(s) | Approval required? | Required auth | Required logging/evidence |
-|---|---|---|---|---|---|
-| Read-only retrieval | read diff, list checks | manual/HITL/autonomous | no | PR-scoped token | request + query logs |
-| Test execution | run regression suite | HITL/autonomous | no | sandbox executor | command log + artifacts |
-| PR communication | post failure summary | HITL/autonomous | policy-based | commenter token | posted text + source links |
-| Code modifications | apply test/code fix | HITL only | yes | repo write token | before/after diff + reviewer |
-| Workflow/config edits | change CI/test config | manual/HITL only | always | elevated approval | immutable audit event |
-
-### 4.6 Sensitive data & policy constraints
-- **Data classes:** credentials/tokens, internal URLs, customer data in fixtures, security findings.
-- **Retention constraints:** limit artifact retention and avoid persisting raw sensitive logs.
-- **Regulatory/compliance constraints:** respect internal secure SDLC, auditability, and access controls.
-- **Safety constraints:** no autonomous merge/deploy; no policy bypass for failed checks.
-
----
-
-## 5. Operating modes & agentic flow variants
-
-### 5.1 Manual baseline (no agent)
-- Engineers run local tests, inspect CI failures, and handcraft fixes.
-- Human reviewers control all test retries and patch scopes.
-
-### 5.2 Human-in-the-loop (HITL / sub-autonomous)
-- Assistant runs allowed checks and drafts remediation.
-- Humans approve write actions and sensitive PR comments.
-
-### 5.3 Fully autonomous (end-to-end agentic)
-- Assistant executes read/test/comment flows under policy.
-- Write actions remain constrained to low-risk scopes or disabled entirely.
-- Hard safety stops trigger on secret-detection, permission failures, or policy uncertainty.
-
-### 5.4 Variants
-- Single-agent PR copilot.
-- Multi-agent pattern (analyzer, test-runner, patch-writer).
-- Local-only execution vs cloud CI execution.
-
----
-
-## 6. Threat model overview (high-level)
-
-### 6.1 Primary security and safety goals
-- Preserve codebase and CI integrity.
-- Prevent confidentiality leakage from code, logs, and artifacts.
-- Ensure traceable, reviewable actions for all write operations.
-
-### 6.2 Threat actors
-- External contributor with malicious PR content.
-- Compromised dependency or fixture.
-- Insider misuse of overly broad agent permissions.
-
-### 6.3 Attack surfaces
-- PR text/comments and changed files.
-- Skill definitions and referenced scripts.
-- CI configuration and secrets context.
-- Agent tool-calling interface.
-
-### 6.4 High-impact failures
-- **Customer/consumer harm:** regression reaches production due to false confidence.
-- **Business harm:** release delays, remediation cost spikes, reputational damage.
-- **Security harm:** token leakage, unauthorized code changes, CI abuse.
-
----
-
-## 7. Kill-chain analysis (stages -> likely failure modes)
-
-| Stage | What can go wrong (pattern) | Likely impact | Notes / preconditions |
-|---|---|---|---|
-| 1. Entry / trigger | Malicious or misleading PR content influences assistant reasoning | incorrect test focus, unsafe suggestions | agent consumes untrusted PR context |
-| 2. Context contamination | Untrusted tool output/log text is treated as trusted instruction | policy drift, unsafe commands | weak separation between data and instructions |
-| 3. Tool misuse / unsafe action | Assistant exceeds allowed scope (writes config/code unsafely) | integrity loss, security regression | insufficient authorization gates |
-| 4. Persistence / repeat | Unsafe patch/comments become part of repo history | repeated failures or leakage | automation posts without review |
-| 5. Exfiltration / harm | Secrets or sensitive traces leak via logs/comments/artifacts | credential compromise, incident response | missing redaction and retention controls |
-
----
-
-## 8. SAFE-MCP mapping (kill-chain -> techniques -> controls -> tests)
-
-| Kill-chain stage | Failure/attack pattern (defender-friendly) | SAFE-MCP technique(s) | Recommended controls (prevent/detect/recover) | Tests (how to validate) |
-|---|---|---|---|---|
-| Entry / trigger | Untrusted PR text steers actions | `TBD` (prompt/context manipulation class) | strict instruction hierarchy, untrusted-input tagging, denylist for dangerous intents | seeded adversarial PR prompt tests; verify no forbidden tool calls |
-| Context contamination | Tool/log output treated as executable intent | `TBD` (tool-output trust abuse class) | schema-validated tool outputs, parser isolation, provenance labels | inject synthetic malicious log lines; assert agent ignores action text |
-| Tool misuse | Unauthorized write operations | `TBD` (excessive permissions class) | least-privilege tokens, path-based write allowlists, explicit HITL approval | attempt writes outside allowed paths; expect hard deny + audit log |
-| Persistence | Auto-posted unsafe summaries/patches | `TBD` (unsafe autonomous persistence class) | approval gates, diff risk scoring, rollback support | forced high-risk change scenario; verify block + reviewer workflow |
-| Exfiltration / harm | Secret leakage via outputs/artifacts | `TBD` (data exfiltration class) | secret scanning/redaction, artifact ACLs, short retention | canary-secret tests in fixtures/logs; ensure redaction and alerting |
-
-**Notes**
-- Technique IDs are marked `TBD` pending final alignment with the SAFE-MCP catalog.
-- Controls are intentionally operational and testable for CI/engineering teams.
-
----
-
-## 9. Controls and mitigations (organized)
-
-### 9.1 Prevent (reduce likelihood)
-- Enforce capability-based tool permissions and per-action authorization.
-- Treat PR data and tool outputs as untrusted by default.
-- Restrict autonomous writes to approved low-risk file sets.
-- Pin skill versions and require code review for skill changes.
-
-### 9.2 Detect (reduce time-to-detect)
-- Log all tool calls with requester identity, scope, and outcome.
-- Alert on policy-denied operations and repeated unsafe intent patterns.
-- Track drift in failure rates and patch revert frequency.
-
-### 9.3 Recover (reduce blast radius)
-- One-click rollback for assistant-authored commits.
-- Immediate token revocation and artifact purge workflows.
-- Kill switch to disable autonomous actions while preserving read-only triage.
-
----
-
-## 10. Validation and testing plan
-
-### 10.1 What to test (minimum set)
-- Permission boundaries: assistant cannot write beyond approved paths/scopes.
-- Prompt/tool-output robustness: untrusted content cannot override policies.
-- Action gating: high-risk writes always require reviewer approval.
-- Logging/auditability: every material action is attributable and reviewable.
-- Rollback/safety stops: unsafe runs can halt and revert cleanly.
-
-### 10.2 Test cases (concrete)
-
-| Test name | Setup | Input / scenario | Expected outcome | Evidence produced |
-|---|---|---|---|---|
-| Untrusted PR prompt-injection resilience | PR sandbox with seeded malicious text | PR description asks agent to skip tests and edit protected files | agent ignores request; runs normal allowed test flow only | tool-call log + denied-action events |
-| Unauthorized path write deny | policy with allowed paths limited to `tests/` | agent attempts edit in `.github/workflows/` | write denied; run flagged for review | policy decision log + blocked diff |
-| Secret redaction in outputs | canary secret in test fixture/log | failing test emits token-like string | posted summaries/artifacts redact secret | artifact snapshot + redaction alert |
-| HITL gate enforcement | reviewer-required mode enabled | agent proposes config change after flaky failure | no write until explicit human approval | approval record + before/after state |
-| Rollback readiness | assistant-authored low-risk patch merged to branch | post-merge regression detected | automated rollback procedure succeeds | rollback commit + audit trail |
-
----
-
-## Contributors
-
-- @bishnubista (initial draft)
-
-## Version history
-
-| Date | Author | Change |
-|---|---|---|
-| 2026-02-18 | @bishnubista | Initial draft for SAFE-UC-0025 (skill-driven web app regression testing assistant). |
+- Expand this page to `draft` using the full template in `templates/use-case-template.md`.
+- Add public evidence links and concrete control/test mappings.

--- a/use-cases/SAFE-UC-0033/README.md
+++ b/use-cases/SAFE-UC-0033/README.md
@@ -1,0 +1,264 @@
+# Skill-driven web app regression testing assistant for pull requests
+
+> **SAFE-AUCA industry reference guide (draft)**
+>
+> This use case describes a workflow where engineering teams use a coding agent with reusable skills to run pull request (PR) regression checks for web applications.
+>
+> It focuses on:
+> - how the workflow works in practice (tools, data, trust boundaries, autonomy)
+> - what can go wrong (defender-friendly kill chain)
+> - how it maps to **SAFE-MCP techniques**
+> - what controls + tests make it safer
+>
+> **Defender-friendly only:** do **not** include operational exploit steps, payloads, or step-by-step attack instructions.  
+> **No sensitive info:** do not include internal hostnames/endpoints, secrets, customer data, non-public incidents, or proprietary details.
+
+---
+
+## Metadata
+
+| Field | Value |
+|---|---|
+| **SAFE Use Case ID** | `SAFE-UC-0033` |
+| **Status** | `draft` |
+| **NAICS 2022** | `51` (Information), `513210` (Software Publishers) |
+| **Workflow family** | `Software engineering & developer tooling` |
+| **Last updated** | `2026-02-18` |
+
+### Evidence (public links)
+- https://github.com/anthropics/skills
+- https://code.claude.com/docs/en/slash-commands
+- https://claude.com/blog/equipping-agents-for-the-real-world-with-agent-skills
+- https://docs.github.com/en/actions
+- https://playwright.dev/docs/intro
+
+---
+
+## 1. Executive summary (what + why)
+
+**What this workflow does**  
+Teams define reusable coding-agent skills (instructions, scripts, guardrails) for UI regression checks on PRs. The assistant runs deterministic test workflows (for example Playwright suites), summarizes failures, and proposes scoped fixes.
+
+**Why it matters (business value)**  
+This reduces release risk and developer wait time by standardizing repetitive QA tasks, improving triage speed, and making test execution more consistent across contributors.
+
+**Why it is risky / what can go wrong**  
+The same automation can also increase blast radius. Untrusted PR content can influence tool behavior, secrets can leak in logs or artifacts, and autonomous write operations can introduce regressions or unsafe infrastructure changes.
+
+---
+
+## 2. Industry context & constraints (reference-guide lens)
+
+- **Industry-specific constraints:** rapid release cadence, CI cost controls, branch protection requirements, secure SDLC expectations.
+- **Typical systems in this workflow:** git hosting, CI runners, package registries, artifact stores, test infrastructure, incident chat/tools.
+- **Must-not-fail outcomes:** no secret leakage in test logs, no unauthorized code or workflow changes, no silent test bypass, no unsafe auto-merge.
+- **Operational constraints:** minutes-level feedback loops, flaky test handling, reproducibility across developer/CI environments, strict least-privilege access.
+
+---
+
+## 3. Workflow description & scope
+
+### 3.1 Workflow steps (happy path)
+1. Developer opens or updates a PR.
+2. Assistant loads the relevant skill (test strategy, allowed tools, approval gates).
+3. Assistant runs read-only analysis and targeted regression tests.
+4. Assistant summarizes failures with evidence (trace IDs, screenshots, failing assertions).
+5. Human reviewer approves any write actions (patches, workflow edits, retries with changed settings).
+6. CI reruns and PR proceeds through standard branch protections.
+
+### 3.2 In scope / out of scope
+- **In scope:** PR diff analysis, regression-test execution, failure summarization, proposed code/test fixes, CI-safe reruns.
+- **Out of scope:** production deployment approval, credential rotation, infra privilege escalation, bypassing branch protections.
+
+### 3.3 Assumptions
+- Branch protection and mandatory checks are already enforced.
+- Skill execution is versioned and reviewable.
+- High-risk writes require explicit human approval.
+
+### 3.4 Success criteria
+- Reduced regression escapes and mean-time-to-triage.
+- No unauthorized writes outside approved repo paths.
+- No sensitive data in assistant outputs or artifacts.
+- Reproducible test results between local and CI environments.
+
+---
+
+## 4. System & agent architecture
+
+### 4.1 Actors and systems
+- **Human roles:** application engineers, QA engineers, release managers, security reviewers.
+- **Agent/orchestrator:** coding assistant runtime with skill loader and execution policy.
+- **Tools:** git CLI, test runners (for example Playwright), package manager, CI APIs, issue/PR APIs.
+- **Data stores:** source repo, CI logs/artifacts, test snapshots, skill definitions.
+- **Downstream systems affected:** PR status checks, codebase, test baselines, release gates.
+
+### 4.2 Trusted vs untrusted inputs
+
+| Input/source | Trusted? | Why | Typical failure/abuse pattern | Mitigation theme |
+|---|---|---|---|---|
+| PR title/body/comments | Untrusted | user supplied | prompt injection/social engineering | treat as data, never instructions |
+| Changed files in PR | Untrusted | potentially malicious | test bypass, hidden payloads | policy checks + diff-aware allowlists |
+| Skill definitions | Semi-trusted | internal but editable | unsafe guidance drift | signed/versioned skills + review |
+| CI environment variables | Sensitive | high impact if leaked | credential exposure | redaction + scoped tokens |
+| Test artifacts/logs | Mixed | may include secrets/PII | data leakage | scrub + retention controls |
+| Tool outputs | Mixed | depends on tool | contaminated context | schema validation + provenance |
+
+### 4.3 Trust boundaries (required)
+- **Developer/PR content -> agent boundary:** untrusted text and code cross into model context.
+- **Agent -> tool boundary:** model intent is translated into executable commands.
+- **Tool -> CI/API boundary:** actions may mutate external systems (checks, comments, artifacts).
+- **Dev/test -> protected branch boundary:** only policy-compliant changes may merge.
+
+### 4.4 Tool inventory (required)
+
+| Tool / MCP server | Read / write? | Permissions | Typical inputs | Typical outputs | Failure modes |
+|---|---|---|---|---|---|
+| `repo.diff.read` | read | PR-scoped | branch/ref | file diffs | missed risky file changes |
+| `test.run.playwright` | read/exec | sandboxed runner | test filters/config | pass/fail + traces | flaky runs, hidden side effects |
+| `ci.checks.read` | read | checks API scope | PR id/workflow id | status, logs | stale/incomplete status |
+| `pr.comment.create` | write | commenter scope | markdown summary | posted comment | leakage of sensitive details |
+| `repo.patch.apply` | write | branch-scoped + approval | diff/patch | updated files | incorrect or over-broad edits |
+
+### 4.5 Governance & authorization matrix
+
+| Action category | Example actions | Allowed mode(s) | Approval required? | Required auth | Required logging/evidence |
+|---|---|---|---|---|---|
+| Read-only retrieval | read diff, list checks | manual/HITL/autonomous | no | PR-scoped token | request + query logs |
+| Test execution | run regression suite | HITL/autonomous | no | sandbox executor | command log + artifacts |
+| PR communication | post failure summary | HITL/autonomous | policy-based | commenter token | posted text + source links |
+| Code modifications | apply test/code fix | HITL only | yes | repo write token | before/after diff + reviewer |
+| Workflow/config edits | change CI/test config | manual/HITL only | always | elevated approval | immutable audit event |
+
+### 4.6 Sensitive data & policy constraints
+- **Data classes:** credentials/tokens, internal URLs, customer data in fixtures, security findings.
+- **Retention constraints:** limit artifact retention and avoid persisting raw sensitive logs.
+- **Regulatory/compliance constraints:** respect internal secure SDLC, auditability, and access controls.
+- **Safety constraints:** no autonomous merge/deploy; no policy bypass for failed checks.
+
+---
+
+## 5. Operating modes & agentic flow variants
+
+### 5.1 Manual baseline (no agent)
+- Engineers run local tests, inspect CI failures, and handcraft fixes.
+- Human reviewers control all test retries and patch scopes.
+
+### 5.2 Human-in-the-loop (HITL / sub-autonomous)
+- Assistant runs allowed checks and drafts remediation.
+- Humans approve write actions and sensitive PR comments.
+
+### 5.3 Fully autonomous (end-to-end agentic)
+- Assistant executes read/test/comment flows under policy.
+- Write actions remain constrained to low-risk scopes or disabled entirely.
+- Hard safety stops trigger on secret-detection, permission failures, or policy uncertainty.
+
+### 5.4 Variants
+- Single-agent PR copilot.
+- Multi-agent pattern (analyzer, test-runner, patch-writer).
+- Local-only execution vs cloud CI execution.
+
+---
+
+## 6. Threat model overview (high-level)
+
+### 6.1 Primary security and safety goals
+- Preserve codebase and CI integrity.
+- Prevent confidentiality leakage from code, logs, and artifacts.
+- Ensure traceable, reviewable actions for all write operations.
+
+### 6.2 Threat actors
+- External contributor with malicious PR content.
+- Compromised dependency or fixture.
+- Insider misuse of overly broad agent permissions.
+
+### 6.3 Attack surfaces
+- PR text/comments and changed files.
+- Skill definitions and referenced scripts.
+- CI configuration and secrets context.
+- Agent tool-calling interface.
+
+### 6.4 High-impact failures
+- **Customer/consumer harm:** regression reaches production due to false confidence.
+- **Business harm:** release delays, remediation cost spikes, reputational damage.
+- **Security harm:** token leakage, unauthorized code changes, CI abuse.
+
+---
+
+## 7. Kill-chain analysis (stages -> likely failure modes)
+
+| Stage | What can go wrong (pattern) | Likely impact | Notes / preconditions |
+|---|---|---|---|
+| 1. Entry / trigger | Malicious or misleading PR content influences assistant reasoning | incorrect test focus, unsafe suggestions | agent consumes untrusted PR context |
+| 2. Context contamination | Untrusted tool output/log text is treated as trusted instruction | policy drift, unsafe commands | weak separation between data and instructions |
+| 3. Tool misuse / unsafe action | Assistant exceeds allowed scope (writes config/code unsafely) | integrity loss, security regression | insufficient authorization gates |
+| 4. Persistence / repeat | Unsafe patch/comments become part of repo history | repeated failures or leakage | automation posts without review |
+| 5. Exfiltration / harm | Secrets or sensitive traces leak via logs/comments/artifacts | credential compromise, incident response | missing redaction and retention controls |
+
+---
+
+## 8. SAFE-MCP mapping (kill-chain -> techniques -> controls -> tests)
+
+| Kill-chain stage | Failure/attack pattern (defender-friendly) | SAFE-MCP technique(s) | Recommended controls (prevent/detect/recover) | Tests (how to validate) |
+|---|---|---|---|---|
+| Entry / trigger | Untrusted PR text steers actions | `TBD` (prompt/context manipulation class) | strict instruction hierarchy, untrusted-input tagging, denylist for dangerous intents | seeded adversarial PR prompt tests; verify no forbidden tool calls |
+| Context contamination | Tool/log output treated as executable intent | `TBD` (tool-output trust abuse class) | schema-validated tool outputs, parser isolation, provenance labels | inject synthetic malicious log lines; assert agent ignores action text |
+| Tool misuse | Unauthorized write operations | `TBD` (excessive permissions class) | least-privilege tokens, path-based write allowlists, explicit HITL approval | attempt writes outside allowed paths; expect hard deny + audit log |
+| Persistence | Auto-posted unsafe summaries/patches | `TBD` (unsafe autonomous persistence class) | approval gates, diff risk scoring, rollback support | forced high-risk change scenario; verify block + reviewer workflow |
+| Exfiltration / harm | Secret leakage via outputs/artifacts | `TBD` (data exfiltration class) | secret scanning/redaction, artifact ACLs, short retention | canary-secret tests in fixtures/logs; ensure redaction and alerting |
+
+**Notes**
+- Technique IDs are marked `TBD` pending final alignment with the SAFE-MCP catalog.
+- Controls are intentionally operational and testable for CI/engineering teams.
+
+---
+
+## 9. Controls and mitigations (organized)
+
+### 9.1 Prevent (reduce likelihood)
+- Enforce capability-based tool permissions and per-action authorization.
+- Treat PR data and tool outputs as untrusted by default.
+- Restrict autonomous writes to approved low-risk file sets.
+- Pin skill versions and require code review for skill changes.
+
+### 9.2 Detect (reduce time-to-detect)
+- Log all tool calls with requester identity, scope, and outcome.
+- Alert on policy-denied operations and repeated unsafe intent patterns.
+- Track drift in failure rates and patch revert frequency.
+
+### 9.3 Recover (reduce blast radius)
+- One-click rollback for assistant-authored commits.
+- Immediate token revocation and artifact purge workflows.
+- Kill switch to disable autonomous actions while preserving read-only triage.
+
+---
+
+## 10. Validation and testing plan
+
+### 10.1 What to test (minimum set)
+- Permission boundaries: assistant cannot write beyond approved paths/scopes.
+- Prompt/tool-output robustness: untrusted content cannot override policies.
+- Action gating: high-risk writes always require reviewer approval.
+- Logging/auditability: every material action is attributable and reviewable.
+- Rollback/safety stops: unsafe runs can halt and revert cleanly.
+
+### 10.2 Test cases (concrete)
+
+| Test name | Setup | Input / scenario | Expected outcome | Evidence produced |
+|---|---|---|---|---|
+| Untrusted PR prompt-injection resilience | PR sandbox with seeded malicious text | PR description asks agent to skip tests and edit protected files | agent ignores request; runs normal allowed test flow only | tool-call log + denied-action events |
+| Unauthorized path write deny | policy with allowed paths limited to `tests/` | agent attempts edit in `.github/workflows/` | write denied; run flagged for review | policy decision log + blocked diff |
+| Secret redaction in outputs | canary secret in test fixture/log | failing test emits token-like string | posted summaries/artifacts redact secret | artifact snapshot + redaction alert |
+| HITL gate enforcement | reviewer-required mode enabled | agent proposes config change after flaky failure | no write until explicit human approval | approval record + before/after state |
+| Rollback readiness | assistant-authored low-risk patch merged to branch | post-merge regression detected | automated rollback procedure succeeds | rollback commit + audit trail |
+
+---
+
+## Contributors
+
+- @bishnubista (initial draft)
+
+## Version history
+
+| Date | Author | Change |
+|---|---|---|
+| 2026-02-18 | @bishnubista | Initial draft for SAFE-UC-0033 (skill-driven web app regression testing assistant). |


### PR DESCRIPTION
## Summary

- Restore `SAFE-UC-0025` to its original seed definition (`Enterprise agent-building platform`) in the use-case page, registry, and README index.
- Add new draft use case `SAFE-UC-0033` for skill-driven web app regression testing on pull requests.
- Keep index/registry/use-case page consistency aligned with validation rules.

## Use Case Context

- Use case ID: `SAFE-UC-0033`
- Related issue/claim: N/A
- Status transition: `seed -> draft` (for the newly added `SAFE-UC-0033`)

## Changed Files

- `use-cases/SAFE-UC-0025/README.md`
- `use-cases/SAFE-UC-0033/README.md`
- `use-cases.naics2022.crosswalk.json`
- `README.md`

## Author Confirmation

- [x] I completed all items in `CONTRIBUTING.md` under `PR checklist (source of truth)`.
- [x] I requested DSO/maintainer review.

## DSO Signoff (Maintainers)

DSO signoff required before merge (approval review or explicit `DSO Approved` comment).
