### PR TITLE
feat: automate SAFE use-case ID intake and clarify draft PR path

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,11 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Existing ID? Open Draft PR
+    url: https://github.com/safe-agentic-framework/safe-agentic-use-cases/compare/main?expand=1
+    about: If you are using an existing SAFE-UC ID, create a Draft PR directly (issue optional).
+  - name: Claim or Propose a Use Case
+    url: https://github.com/safe-agentic-framework/safe-agentic-use-cases/issues/new?template=use-case-claim.yml
+    about: For new IDs, choose "Propose new ID" and set SAFE Use Case ID to "new".
   - name: Contribution Guide
     url: https://github.com/safe-agentic-framework/safe-agentic-use-cases/blob/main/CONTRIBUTING.md
     about: Read contribution, safety, and DSO requirements before opening issues.

--- a/.github/ISSUE_TEMPLATE/use-case-claim.yml
+++ b/.github/ISSUE_TEMPLATE/use-case-claim.yml
@@ -1,6 +1,6 @@
 name: Use Case Claim / Proposal
 description: Claim an existing seed ID or propose a new SAFE use-case entry
-title: "[Use Case] SAFE-UC-____ - <short title>"
+title: "[Use Case] NEW - <short title>"
 labels:
   - use-case
   - triage
@@ -9,6 +9,9 @@ body:
     attributes:
       value: |
         Use this form to coordinate contributions and avoid duplicate work.
+        - If you are using an existing `SAFE-UC-XXXX`, you can open a Draft PR directly and skip this issue form.
+        - For **Claim existing seed ID**: enter the exact `SAFE-UC-XXXX` from `README.md`.
+        - For **Propose new ID**: enter `new` and automation will assign the next available ID.
 
   - type: dropdown
     id: request_type
@@ -24,8 +27,8 @@ body:
     id: use_case_id
     attributes:
       label: SAFE Use Case ID
-      description: Use existing ID (e.g. SAFE-UC-0012) or write "new" if proposing.
-      placeholder: SAFE-UC-____
+      description: For existing claims use `SAFE-UC-XXXX` (e.g. `SAFE-UC-0012`). For new IDs enter `new`.
+      placeholder: SAFE-UC-0012 or new
     validations:
       required: true
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,7 @@ Follow [`CONTRIBUTING.md`](../CONTRIBUTING.md). This template only captures PR c
 ## Use Case Context
 
 - Use case ID: `SAFE-UC-____`
-- Related issue/claim: #
+- Related issue/claim (optional for existing IDs): # / N/A
 - Status transition: `seed -> draft` / `draft -> published` / `seed -> published`
 
 ## Changed Files

--- a/.github/workflows/assign-use-case-id.yml
+++ b/.github/workflows/assign-use-case-id.yml
@@ -1,0 +1,276 @@
+name: Assign SAFE Use Case ID
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: safe-use-case-id-intake
+  cancel-in-progress: false
+
+jobs:
+  assign-or-validate:
+    if: contains(github.event.issue.labels.*.name, 'use-case')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Assign or validate SAFE use case ID
+        uses: actions/github-script@v7
+        env:
+          REGISTRY_FILE: use-cases.naics2022.crosswalk.json
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs");
+
+            const BOT_MARKER = "<!-- safe-use-case-id-bot -->";
+            const REQUEST_TYPE_NEW = "propose new id";
+            const REQUEST_TYPE_EXISTING = "claim existing seed id";
+            const ID_REGEX = /SAFE-UC-\d{4}/g;
+
+            const issue = context.payload.issue;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = issue.number;
+
+            const normalize = (value) => (value || "").replace(/\r/g, "").trim();
+            const cleanField = (value) => {
+              const normalized = normalize(value).replace(/\n+/g, " ").replace(/^`|`$/g, "").trim();
+              if (!normalized || /^_?no response_?$/i.test(normalized)) {
+                return "";
+              }
+              return normalized;
+            };
+
+            const parseFormSections = (body) => {
+              const sections = {};
+              let heading = null;
+              let sectionLines = [];
+
+              for (const line of normalize(body).split("\n")) {
+                if (line.startsWith("### ")) {
+                  if (heading) {
+                    sections[heading] = normalize(sectionLines.join("\n"));
+                  }
+                  heading = line.slice(4).trim();
+                  sectionLines = [];
+                  continue;
+                }
+                if (heading) {
+                  sectionLines.push(line);
+                }
+              }
+
+              if (heading) {
+                sections[heading] = normalize(sectionLines.join("\n"));
+              }
+
+              return sections;
+            };
+
+            const extractIds = (text) => {
+              const matches = normalize(text).toUpperCase().match(ID_REGEX) || [];
+              return new Set(matches);
+            };
+
+            const formatId = (number) => `SAFE-UC-${String(number).padStart(4, "0")}`;
+
+            const listBotComment = async () => {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: issueNumber,
+                per_page: 100,
+              });
+
+              return comments.find(
+                (comment) =>
+                  comment.user?.login === "github-actions[bot]" &&
+                  comment.body?.includes(BOT_MARKER)
+              );
+            };
+
+            const upsertBotComment = async (message) => {
+              const body = `${BOT_MARKER}\n${message}`;
+              const existing = await listBotComment();
+
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner,
+                  repo,
+                  comment_id: existing.id,
+                  body,
+                });
+                return;
+              }
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body,
+              });
+            };
+
+            const clearBotComment = async () => {
+              const existing = await listBotComment();
+              if (!existing) {
+                return;
+              }
+
+              await github.rest.issues.deleteComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+              });
+            };
+
+            const ensureTitleHasId = async (safeId) => {
+              let nextTitle = issue.title || "";
+
+              if (/SAFE-UC-\d{4}/i.test(nextTitle)) {
+                nextTitle = nextTitle.replace(/SAFE-UC-\d{4}/i, safeId);
+              } else if (/SAFE-UC-____/i.test(nextTitle)) {
+                nextTitle = nextTitle.replace(/SAFE-UC-____/i, safeId);
+              } else if (/^\[Use Case\]/i.test(nextTitle)) {
+                const rest = nextTitle
+                  .replace(/^\[Use Case\]\s*/i, "")
+                  .replace(/^NEW\s*-\s*/i, "")
+                  .trim();
+                nextTitle = `[Use Case] ${safeId}${rest ? ` - ${rest}` : ""}`;
+              } else {
+                nextTitle = `[Use Case] ${safeId} - ${nextTitle}`.trim();
+              }
+
+              if (nextTitle !== issue.title) {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  title: nextTitle,
+                });
+              }
+            };
+
+            const sections = parseFormSections(issue.body || "");
+            const requestType = cleanField(sections["Request type"]).toLowerCase();
+            const idField = cleanField(sections["SAFE Use Case ID"]);
+            const idInput = idField.toUpperCase();
+
+            if (!requestType || !idField) {
+              core.info("Issue body is missing expected form fields; skipping.");
+              return;
+            }
+
+            const registry = JSON.parse(fs.readFileSync(process.env.REGISTRY_FILE, "utf8"));
+            const registryIds = new Set(registry.map((entry) => String(entry.id).toUpperCase()));
+
+            const openUseCaseIssues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: "open",
+              labels: "use-case",
+              per_page: 100,
+            });
+
+            const otherIssueIds = new Set();
+            const idToIssues = new Map();
+
+            for (const openIssue of openUseCaseIssues) {
+              if (openIssue.number === issueNumber || openIssue.pull_request) {
+                continue;
+              }
+
+              const ids = extractIds(`${openIssue.title}\n${openIssue.body || ""}`);
+              for (const id of ids) {
+                otherIssueIds.add(id);
+                if (!idToIssues.has(id)) {
+                  idToIssues.set(id, []);
+                }
+                idToIssues.get(id).push(openIssue.number);
+              }
+            }
+
+            if (requestType === REQUEST_TYPE_NEW) {
+              if (idInput !== "NEW") {
+                await upsertBotComment(
+                  "Please set **SAFE Use Case ID** to `new` when using **Propose new ID**."
+                );
+                return;
+              }
+
+              const idsInCurrentIssue = extractIds(`${issue.title}\n${issue.body || ""}`);
+              const existingAssignedId = [...idsInCurrentIssue].find((id) => !registryIds.has(id));
+
+              let assignedId = existingAssignedId;
+              if (!assignedId) {
+                const numericParts = [...registryIds, ...otherIssueIds].map((id) => Number(id.slice(-4)));
+                let next = Math.max(0, ...numericParts) + 1;
+                assignedId = formatId(next);
+
+                while (registryIds.has(assignedId) || otherIssueIds.has(assignedId)) {
+                  next += 1;
+                  assignedId = formatId(next);
+                }
+              }
+
+              await ensureTitleHasId(assignedId);
+              await upsertBotComment(
+                [
+                  `Assigned SAFE Use Case ID: \`${assignedId}\`.`,
+                  "",
+                  "Use this ID in:",
+                  `- \`use-cases/${assignedId}/README.md\``,
+                  "- `use-cases.naics2022.crosswalk.json`",
+                ].join("\n")
+              );
+              return;
+            }
+
+            if (requestType === REQUEST_TYPE_EXISTING) {
+              if (!/^SAFE-UC-\d{4}$/.test(idInput)) {
+                await upsertBotComment(
+                  "For **Claim existing seed ID**, enter an ID in the exact format `SAFE-UC-XXXX`."
+                );
+                return;
+              }
+
+              if (!registryIds.has(idInput)) {
+                await upsertBotComment(
+                  [
+                    `\`${idInput}\` is not in the current registry.`,
+                    "If this is a net-new workflow, use **Propose new ID** and set **SAFE Use Case ID** to `new`.",
+                  ].join("\n")
+                );
+                return;
+              }
+
+              const conflictingIssues = idToIssues.get(idInput) || [];
+              if (conflictingIssues.length > 0) {
+                const refs = conflictingIssues.map((number) => `#${number}`).join(", ");
+                await upsertBotComment(
+                  [
+                    `Heads up: \`${idInput}\` is already referenced by open issue(s): ${refs}.`,
+                    "Coordinate in-thread to avoid duplicate work on the same ID.",
+                  ].join("\n")
+                );
+                return;
+              }
+
+              await clearBotComment();
+              return;
+            }
+
+            await upsertBotComment(
+              `Unrecognized **Request type** value: "${requestType}". Choose **Claim existing seed ID** or **Propose new ID**.`
+            );

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,7 +69,10 @@ Rules:
 SAFE Use Case IDs are stable and never reused.
 
 - Prefer adopting an existing `seed` from the root README index.
-- If you need a new one, pick the next monotonically increasing ID: `SAFE-UC-0001`, `SAFE-UC-0002`, …
+- If you are using an existing ID, you can open a Draft PR directly (issue claim is optional).
+- If you need a new ID, open a **Use Case Claim / Proposal** issue and choose **Propose new ID**.
+- In that issue form, set **SAFE Use Case ID** to `new`. Automation assigns the next available `SAFE-UC-XXXX` and updates the issue title.
+- Do not manually choose a numeric new ID in the issue form.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Safety rules (non‑negotiable): **no sensitive info, no exploit instructions, g
 
 Quick contributor workflow:
 - Read [`CONTRIBUTING.md`](CONTRIBUTING.md) (source of truth).
-- Claim/propose work via [Use Case Claim / Proposal](.github/ISSUE_TEMPLATE/use-case-claim.yml).
+- If using an existing `SAFE-UC-XXXX`, you can open a Draft PR directly.
+- Claim/propose work via [Use Case Claim / Proposal](.github/ISSUE_TEMPLATE/use-case-claim.yml) (`new` auto-assigns the next SAFE-UC ID).
 - Ensure PR check **`Registry and Docs Validation`** passes.
 - Get required DSO signoff before merge (details in `CONTRIBUTING.md`).
 


### PR DESCRIPTION
## Before You Submit

Follow [`CONTRIBUTING.md`](../CONTRIBUTING.md). This template only captures PR context.

- Source of truth checklist: `CONTRIBUTING.md` -> `PR checklist (source of truth)`
- Required policy sections: safety/disclosure rules, status definitions, contribution flow, and DSO signoff
- If this template and `CONTRIBUTING.md` differ, `CONTRIBUTING.md` wins
- Automated checks run in GitHub Actions: [`.github/workflows/validate-contributions.yml`](./workflows/validate-contributions.yml)

## Summary

Introduce conflict-safe SAFE use-case ID intake automation and align contributor messaging:
- auto-assign next `SAFE-UC-XXXX` for net-new proposals (`use_case_id = new`)
- validate existing ID claims and flag open-issue collisions
- clarify that contributors using an existing ID can open a Draft PR directly (issue optional)

## Use Case Context

- Use case ID: `N/A (repo process/automation change)`
- Related issue/claim (optional for existing IDs): N/A
- Status transition: `N/A`

## Changed Files

- `.github/workflows/assign-use-case-id.yml`
- `.github/ISSUE_TEMPLATE/use-case-claim.yml`
- `.github/ISSUE_TEMPLATE/config.yml`
- `.github/pull_request_template.md`
- `CONTRIBUTING.md`
- `README.md`

## Author Confirmation

- [x] I completed all items in `CONTRIBUTING.md` under `PR checklist (source of truth)`.
- [x] I requested DSO/maintainer review.

## DSO Signoff (Maintainers)

DSO signoff required before merge (approval review or explicit `DSO Approved` comment).
